### PR TITLE
fix: destruct JWE key for encryption and mac key parts

### DIFF
--- a/src/OpenKMS.Aes/AesEncryptionHandler.cs
+++ b/src/OpenKMS.Aes/AesEncryptionHandler.cs
@@ -69,8 +69,11 @@ public class AesEncryptionHandler : EncryptionHandler<AesEncryptionOptions>, IEn
         if (iv == null)
             throw new ArgumentNullException(nameof(iv));
 
+        // TODO Verify integrity and authenticity
+        var encKey = key.K![..(key.K!.Length / 2)];
+
         using var aes = System.Security.Cryptography.Aes.Create();
-        aes.Key = key.K!;
+        aes.Key = encKey;
         aes.IV = iv;
 
         return Task.FromResult(aes.DecryptCbc(ciphertext, iv));


### PR DESCRIPTION
<!-- Describe your changes in detail -->
## Description

- Fixes key usage when decrypting with `A256CBC-HS512` and `A128CBC-HS256`

<!-- Please describe in detail how teammates can test your changes. -->
## Testing required outside of automated testing?

- [X] Not Applicable

<!-- Provide Screenshots when applicable -->
### Screenshots (if appropriate):

- [X] Not Applicable

<!-- Describe Rollback or Roll-forward Procedure -->
## Rollback / Roll-forward Procedure

- [X] Roll Forward
- [ ] Roll Back

## Reviewer Checklist

- [ ] Description of Change
- [ ] Description of outside testing if applicable.
- [ ] Description of Roll Forward / Backward Procedure
- [ ] Documentation updated for Change
